### PR TITLE
Usability improvements, bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ monitor.mem:	monitor.srec
 	$(TRIM) -o $@ $<
 
 monitor.srec: $(OBJS)
-	$(LD) -v -Ttext 0x80000 -Ebss 0x04000 -o $@ $(OBJS)
+	$(LD) -Ttext 0x80000 -Ebss 0x04000 -o $@ $(OBJS)
 
 .PHONY: clean clobber
 clean:

--- a/cli.c
+++ b/cli.c
@@ -57,7 +57,7 @@ void welcome()
 {
   printf("\n");
   printf("+------------------------------------------------+\n");
-  printf("|                 WRAMPmon 0.8                   |\n");
+  printf("|                 WRAMPmon 0.9                   |\n");
   printf("| Copyright 2002-2019 The University of Waikato  |\n");
   printf("|                                                |\n");
   printf("|          Written by Dean Armstrong             |\n");

--- a/commands.c
+++ b/commands.c
@@ -199,6 +199,7 @@ void command_help()
 	 " cont                               Continue executing a program\n" \
 	 " s                                  Step\n" \
 	 " so                                 Step over\n" \
+	 " cls                                Clear both serial ports\n" \
 	 " about                              Display information about this system\n" \
 	 " help or ?                          Display this information\n\n" \
 	 "More information about indivdual commands can be obtained by entering\n" \
@@ -943,10 +944,18 @@ void command_cont()
 }
 
 void command_cls(){
+  // Clears screen, then sets cursor position to home
+  char* escape_code = "\\033[2J\\033[H";
+  int i = 0;
 
-	printf("\\033[2J");
+  while (escape_code[i] != 0)
+  {
+    send_char(escape_code[i]);
+    send_char2(escape_code[i]);
+    i++;
+  }
 
-	return;
+  return;
 }
 
 unsigned get_word()

--- a/games/breakout.c
+++ b/games/breakout.c
@@ -123,6 +123,9 @@ void GotoXY(int x, int y)
 {
 	if(1 || 0 <= x && x < WIDTH && 0 <= y && y < HEIGHT)
 	{
+        x += 1;
+        y += 1;
+        
 		puts(ASCII_ESC);
 		x %= 100;
 		y %= 100;

--- a/games/wramp.h
+++ b/games/wramp.h
@@ -30,9 +30,12 @@ typedef volatile struct
 	int Iack;
 } WrampSp_t;
 
-//TODO: bit flag defines
-#define WRAMP_SP_RDR	0x0001
-
+// Bit flag defines
+#define WRAMP_SP_TDS		0x002
+#define WRAMP_SP_RDR		0x001
+#define WRAMP_SP_ERR_IE		0x400
+#define WRAMP_SP_TDS_IE		0x200
+#define WRAMP_SP_RDR_IE		0x100
 
 /**
  * WRAMP Timer
@@ -44,6 +47,9 @@ typedef volatile struct
 	int Count;
 	int Iack;
 } WrampTimer_t;
+
+#define WRAMP_TIMER_RESTART		0x2
+#define WRAMP_TIMER_ENABLE		0x1
  
 /**
  * WRAMP Parallel Port
@@ -56,8 +62,15 @@ typedef volatile struct
 	int RightSSD;
 	int Ctrl;
 	int Iack;
+	int UpperLeftSSD;
+	int UpperRightSSD;
+	int LowerLeftSSD;
+	int LowerRightSSD;
+	int LED;
 } WrampParallel_t;
 
+#define WRAMP_PAR_IE			0x2
+#define WRAMP_PAR_HEX_DECODE	0x1
  
 /**
  * WRAMP User Interrupt Button

--- a/termio.S
+++ b/termio.S
@@ -46,6 +46,17 @@ send_char:
 	
 	jr	$ra
 
+# void send_char2(char ch)
+# contains a character to be sent on the second serial port
+.global	send_char2
+send_char2:
+	lw	$1, 0x71003($0)		# Get LSR
+	andi	$1, $1, 0x2		# Look at TDS bit
+	beqz	$1, send_char2		# Wait for previous character to be sent
 
+	lw	$1, 0($sp)		# Get the character
+	sw	$1, 0x71000($0)		# Send the character
+	
+	jr	$ra
 
 


### PR DESCRIPTION
- Makefile doesn't link verbosely anymore
- cls command clears both terminals properly and is listed in help
- Breakout doesn't send invalid escape sequences anymore (Solves specific instance of the issue described by wandwramp/wsim#11, but does not address root cause)
- wramp.h updated to represent basys boards and include a few useful #define statements